### PR TITLE
Updated sorting for a pandas series since it was broken for python 3.6.3

### DIFF
--- a/pandas_sklearn.ipynb
+++ b/pandas_sklearn.ipynb
@@ -440,7 +440,7 @@
    "outputs": [],
    "source": [
     "education_map = grouper.education_num.unique()\n",
-    "education_map.sort()\n",
+    "education_map.sort_values(inplace=True)\n",
     "\n",
     "with pd.option_context(\"max_rows\", 20):\n",
     "    print(education_map)"
@@ -455,7 +455,7 @@
    "outputs": [],
    "source": [
     "grouper.education_num.apply(lambda x : x.unique()[0])\n",
-    "education_map.sort()\n",
+    "education_map.sort_values(inplace=True)\n",
     "\n",
     "with pd.option_context(\"max_rows\", 20):\n",
     "    print(education_map)"


### PR DESCRIPTION
Hello sir,

your presentation on pandas is the best overviews I've encountered.

I noticed a minor deprecation error in the notebook and would like to update it - please review the commit

How to test:
- install python 3.6.x
- try runnning the master notebook up to and including the groupby operators section
- pull this branch
- after running again, the sorting should work